### PR TITLE
Add auth to gateway

### DIFF
--- a/services/common/jwt/jwt.go
+++ b/services/common/jwt/jwt.go
@@ -37,7 +37,7 @@ func ExtractUserFromToken(token string) (uint64, error) {
 			return nil, errors.New(fmt.Sprintf("unexpected signing method: %v", token.Header["alg"]))
 		}
 
-		return key, nil
+		return []byte(key), nil
 	})
 	if err != nil {
 		return 0, err
@@ -49,8 +49,13 @@ func ExtractUserFromToken(token string) (uint64, error) {
 			return 0, errors.New("issuers mismatch")
 		}
 
-		if sub, ok = claims[subKey].(uint64); !ok {
+		subString, ok := claims[subKey].(string)
+		if !ok {
 			return 0, errors.New("missing sub claim")
+		}
+
+		if sub, err = strconv.ParseUint(subString, 10, 64); err != nil {
+			return 0, errors.New("failed to parse sub")
 		}
 	}
 

--- a/services/gateway/cmd/gateway.go
+++ b/services/gateway/cmd/gateway.go
@@ -7,9 +7,10 @@ import (
 	"os"
 
 	"github.com/caarlos0/env/v6"
-	"pad/services/catalogue/client"
+	catalogueClient "pad/services/catalogue/client"
 	"pad/services/gateway/internal/config"
 	"pad/services/gateway/internal/http/server"
+	userClient "pad/services/user/client"
 )
 
 var (
@@ -33,12 +34,17 @@ func main() {
 
 	//ctx := context.Background()
 
-	catalogueClient, err := client.NewCatalogueClient(cfg.ServiceAddress)
+	catalogue, err := catalogueClient.NewCatalogueClient(cfg.ServiceAddress)
 	if err != nil {
 		osError("failed to connect to catalogue server: %v", err)
 	}
 
-	srv := server.NewGatewayServer(catalogueClient)
+	user, err := userClient.NewUserClient(cfg.UserAddress)
+	if err != nil {
+		osError("failed to connect to user server: %v", err)
+	}
+
+	srv := server.NewGatewayServer(catalogue, user)
 
 	log.Println("Starting the server")
 	if err := srv.Start(fmt.Sprintf("127.0.0.1:%d", cfg.Port)); err != nil {

--- a/services/gateway/internal/config/config.go
+++ b/services/gateway/internal/config/config.go
@@ -5,4 +5,5 @@ type Config struct {
 
 	ServiceAddress string `env:"SERVICE_ADDRESS" envDefault:"localhost:22000"`
 	CacheAddress   string `env:"CACHE_ADDRESS" envDefault:"localhost:23000"`
+	UserAddress    string `env:"USER_ADDRESS" envDefault:"localhost:24000"`
 }

--- a/services/gateway/internal/http/middlewares/jwt.go
+++ b/services/gateway/internal/http/middlewares/jwt.go
@@ -1,0 +1,31 @@
+package middlewares
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	"pad/services/common/jwt"
+)
+
+func TokenAuthMiddleware() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		bearToken := c.GetHeader("Authorization")
+		strArr := strings.Split(bearToken, " ")
+		if len(strArr) != 2 {
+			c.JSON(http.StatusUnauthorized, fmt.Errorf("authorization token not found"))
+			c.Abort()
+			return
+		}
+
+		userID, err := jwt.ExtractUserFromToken(strArr[1])
+		if err != nil {
+			c.JSON(http.StatusUnauthorized, err.Error())
+			c.Abort()
+			return
+		}
+		c.Set("userID", userID)
+		c.Next()
+	}
+}

--- a/services/gateway/internal/http/server/gateway.go
+++ b/services/gateway/internal/http/server/gateway.go
@@ -91,7 +91,7 @@ func (g *Gateway) Login(ctx *gin.Context) {
 	}
 
 	httpresponse.RespondOK(ctx, gin.H{
-		"token": token,
+		"token": token.Token,
 	})
 }
 

--- a/services/gateway/internal/http/server/gateway.go
+++ b/services/gateway/internal/http/server/gateway.go
@@ -9,6 +9,7 @@ import (
 	"pad/services/catalogue/services/catalogue"
 	"pad/services/gateway/internal/http/httperr"
 	"pad/services/gateway/internal/http/httpresponse"
+	"pad/services/gateway/internal/http/middlewares"
 	"pad/services/gateway/internal/models"
 	"pad/services/user/services/user"
 )
@@ -34,8 +35,10 @@ func (g *Gateway) Start(address string) error {
 
 	v1 := router.Group("/v1")
 	{
-		v1.POST("/listing", g.CreateListing)
-		v1.GET("/listing", g.GetListing)
+		v1.POST("/register", g.Register)
+		v1.POST("/login", g.Login)
+		v1.POST("/listing", middlewares.TokenAuthMiddleware(), g.CreateListing)
+		v1.GET("/listing", middlewares.TokenAuthMiddleware(), g.GetListing)
 	}
 
 	if err := router.Run(address); err != nil {
@@ -65,6 +68,30 @@ func (g *Gateway) Register(ctx *gin.Context) {
 
 	httpresponse.RespondOK(ctx, gin.H{
 		"successful": "user registered",
+	})
+}
+
+func (g *Gateway) Login(ctx *gin.Context) {
+	var credentials models.Credentials
+
+	if err := ctx.BindJSON(&credentials); err != nil {
+		log.Printf("received bad request: %v\n", err)
+		httperr.Handle(ctx, httperr.NewErrorBadRequest(err))
+		return
+	}
+
+	token, err := g.user.Login(ctx, &user.LoginRequest{
+		Name:     credentials.Name,
+		Password: credentials.Password,
+	})
+	if err != nil {
+		log.Printf("failed to register: %v\n", err)
+		httperr.Handle(ctx, httperr.NewErrorUnauthorized())
+		return
+	}
+
+	httpresponse.RespondOK(ctx, gin.H{
+		"token": token,
 	})
 }
 

--- a/services/gateway/internal/models/credentials.go
+++ b/services/gateway/internal/models/credentials.go
@@ -1,0 +1,6 @@
+package models
+
+type Credentials struct {
+	Name     string `json:"name"`
+	Password string `json:"password"`
+}


### PR DESCRIPTION
Added authentication to gateway service
- Gateway communicates with user service 
- Login and Register gateway endpoints are now available
- Every other HTTP endpoint requires Bearer token